### PR TITLE
fix: fork PR 지원을 위한 Claude Code 워크플로우 수정

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,11 +25,6 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 1
-
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary
- fork PR 지원을 위해 수동 checkout 단계 제거
- claude-code-action이 내부적으로 fork PR을 자동 처리하도록 개선

## 문제 상황

기존 워크플로우에서는 수동 checkout 단계가 upstream 저장소만 체크아웃하여, fork PR에서 다음 에러가 발생:
```
fatal: couldn't find remote ref <branch-name>
Error: Prepare step failed
```

## 해결 방법

- **수동 checkout 단계 제거**: claude-code-action이 PR context를 인식하여 적절한 저장소(fork)에서 자동으로 체크아웃
- fork PR과 동일 저장소 PR 모두 지원

## 변경된 파일

`.github/workflows/claude.yml`:
- `actions/checkout@v5` 단계 제거
- claude-code-action이 fork PR을 올바르게 처리

## Test plan
- [ ] fork PR에서 @claude 멘션 작동 확인
- [ ] 동일 저장소 PR에서도 정상 작동 확인
- [ ] 이슈/PR 코멘트에서 @claude 트리거 테스트

## 참고
- [Claude review fails on PRs from forks · Issue #339](https://github.com/anthropics/claude-code-action/issues/339)

🤖 Generated with [Claude Code](https://claude.com/claude-code)